### PR TITLE
Add file drop event to ModList (install mod zips by dragging them into the list)

### DIFF
--- a/RyuGUI/MainWindow.xaml
+++ b/RyuGUI/MainWindow.xaml
@@ -53,7 +53,7 @@
 
                     <TextBlock Grid.Row="0" Margin="20" Text="MOD LOAD ORDER (Hover for more information)" ToolTip="Mods will get loaded in order (top to bottom).&#x0a;&#x0a;If a mod has a file conflict with another, the files&#x0a;of the latest mod to load will have priority." Foreground="LightGray"/>
 
-                    <ListView x:Name="ModListView" Grid.Row="1" ItemsSource="{Binding ModList, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:MainWindow}}}" Margin="20,0,20,20" Background="#FF4B4B4B" Foreground="White" Opacity="0.8" Height="Auto" VerticalAlignment="Stretch" d:ItemsSource="{d:SampleData ItemCount=5}" SelectionChanged="ModListView_SelectionChanged">
+                    <ListView x:Name="ModListView" Grid.Row="1" ItemsSource="{Binding ModList, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:MainWindow}}}" Margin="20,0,20,20" Background="#FF4B4B4B" Foreground="White" Opacity="0.8" Height="Auto" VerticalAlignment="Stretch" d:ItemsSource="{d:SampleData ItemCount=5}" SelectionChanged="ModListView_SelectionChanged" AllowDrop="True" Drop="ModListView_Drop">
                         <ListView.View>
                             <GridView>
                                 <GridViewColumn Header="Enabled" Width="50">


### PR DESCRIPTION
(also did some changes to how zips are extracted, I replaced the whole manual copy with a `Stream.copyTo` call to make the code easier to read, then I also put the zip file into a `using` statement so that it gets closed and doesn't take up memory after the function is done.)