### PR TITLE
Refresh list when mods folder gets modified, show game name on `MainWindow`'s title bar

### DIFF
--- a/RyuGUI/MainWindow.xaml.cs
+++ b/RyuGUI/MainWindow.xaml.cs
@@ -29,6 +29,8 @@ namespace RyuGUI
             InitializeComponent();
             lbl_SRMMVersion.Content = $"v{Util.GetAppVersion()}";
 
+            this.Title = $"Shin Ryu Mod Manager [{Utils.GamePath.GetGameFriendlyName(Utils.GamePath.GetGame())}]";
+
             if (!Directory.Exists("mods"))
                 Directory.CreateDirectory("mods");
 

--- a/RyuGUI/MainWindow.xaml.cs
+++ b/RyuGUI/MainWindow.xaml.cs
@@ -21,12 +21,22 @@ namespace RyuGUI
     public partial class MainWindow : Window
     {
         public ObservableCollection<ModInfo> ModList { get; set; }
+        private FileSystemWatcher modsFolderWatcher;
 
 
         public MainWindow()
         {
             InitializeComponent();
             lbl_SRMMVersion.Content = $"v{Util.GetAppVersion()}";
+
+            if (!Directory.Exists("mods"))
+                Directory.CreateDirectory("mods");
+
+            modsFolderWatcher = new FileSystemWatcher("mods");
+            modsFolderWatcher.Created += (o, args) => { Dispatcher.Invoke(() => Refresh()); };
+            modsFolderWatcher.Deleted += (o, args) => { Dispatcher.Invoke(() => Refresh()); };
+            modsFolderWatcher.Renamed += (o, args) => { Dispatcher.Invoke(() => Refresh()); };
+            modsFolderWatcher.EnableRaisingEvents = true;
         }
 
 

--- a/Utils/GamePath.cs
+++ b/Utils/GamePath.cs
@@ -145,6 +145,25 @@ namespace Utils
             return currentGame.Value;
         }
 
+        public static string GetGameFriendlyName(Game g) {
+            return g switch
+            {
+                Game.Yakuza3 => "Yakuza 3 Remastered",
+                Game.Yakuza4 => "Yakuza 4 Remastered",
+                Game.Yakuza5 => "Yakuza 5 Remastered",
+                Game.Yakuza0 => "Yakuza 0",
+                Game.YakuzaKiwami => "Yakuza Kiwami",
+                Game.Yakuza6 => "Yakuza 6",
+                Game.YakuzaKiwami2 => "Yakuza Kiwami 2",
+                Game.YakuzaLikeADragon => "Yakuza: Like a Dragon",
+                Game.Judgment => "Judgment",
+                Game.LostJudgment => "Lost Judgment",
+                Game.likeadragongaiden => "Like a Dragon Gaiden: The Man Who Erased His Name",
+                Game.likeadragon8 => "Like a Dragon: Infinite Wealth",
+                _ => "<unknown>"
+            };
+        }
+
         public static string GetGameExe()
         {
             return currentGame.ToString() + ".exe";


### PR DESCRIPTION
It's me again, I added a `FileSystemWatcher` so that the mods list refreshes every time something changes in the `mods` folder. For this to work I also had to ensure this folder exists on startup

I made it show the name of the game it's applying mods to on the title bar too, just a small QOL thing